### PR TITLE
WEBDAM-84 - Fix Undefined Index notice for $bundle->field_map[file]

### DIFF
--- a/src/Plugin/MediaEntity/Type/WebdamAsset.php
+++ b/src/Plugin/MediaEntity/Type/WebdamAsset.php
@@ -219,8 +219,10 @@ class WebdamAsset extends MediaTypeBase {
     // Download the webdam asset file as a string.
     $file_contents = $this->webdam->downloadAsset($asset->id);
     // Set the path for webdam assets.
-    // If the bundle has a field mapped for the file.
-    if ($file_field = $bundle->field_map['file']) {
+    // If the bundle has a field mapped for the file define it.
+    $file_field = isset($bundle->field_map['file']) ? $bundle->field_map['file'] : '';
+    // Define path.
+    if ($file_field) {
       // Get the storage scheme for the file field.
       $scheme = $field_definitions[$file_field]->getItemDefinition()->getSetting('uri_scheme');
     }


### PR DESCRIPTION
Undefined index php notice fixed.
The Notice showed when you added a "Webdam Asset" media entity 'manually' using the webdam "Asset ID". 
[Video](https://youtu.be/lTcdrcgSnn0?t=166) reproducing the issue.